### PR TITLE
fix: sanction limit fix

### DIFF
--- a/erpnext/loan_management/doctype/loan/loan.py
+++ b/erpnext/loan_management/doctype/loan/loan.py
@@ -297,7 +297,7 @@ def get_total_loan_amount(applicant_type, applicant, company):
 			"company": company,
 			"applicant": applicant,
 			"docstatus": 1,
-			"status": ("!=", "Closed"),
+			"status": ("not in", ["Closed", "Sanctioned"]),
 		},
 		fields=[
 			"status",


### PR DESCRIPTION
Exclude loans with status of Closed and Sanctioned when calculating the total loan amount